### PR TITLE
WIP: flatten Login struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 website/build
 target
 credentials.json
+logins.jwk
 *-engine.json
 *.db
 .*.swp

--- a/components/logins/README.md
+++ b/components/logins/README.md
@@ -89,7 +89,9 @@ To effectively work on the Logins component, you will need to be familiar with:
 
 ### Implementation Overview
 
-Logins implements encrypted storage for login records on top of NSS. The storage schema is based on the one
+Logins implements encrypted storage for login records on top of a consumer
+implemented EncryptorDecryptor, or via ManagedEncryptorDecryptor, using NSS
+based crypto algorithms (AES256-GCM). The storage schema is based on the one
 originally used in [Firefox for
 iOS](https://github.com/mozilla-mobile/firefox-ios/blob/faa6a2839abf4da2c54ff1b3291174b50b31ab2c/Storage/SQL/SQLiteLogins.swift),
 but with the following notable differences:

--- a/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
+++ b/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
@@ -21,11 +21,12 @@ import org.mozilla.appservices.logins.GleanMetrics.LoginsStore as LoginsStoreMet
  * LoginStore.
  */
 
-class DatabaseLoginsStorage(dbPath: String) : AutoCloseable {
+class DatabaseLoginsStorage(dbPath: String, keyManager: KeyManager) : AutoCloseable {
     private var store: LoginStore
 
     init {
-        this.store = LoginStore(dbPath)
+        val encdec = createManagedEncdec(keyManager)
+        this.store = LoginStore(dbPath, encdec)
     }
 
     @Throws(LoginsApiException::class)
@@ -46,7 +47,7 @@ class DatabaseLoginsStorage(dbPath: String) : AutoCloseable {
     }
 
     @Throws(LoginsApiException::class)
-    fun get(id: String): EncryptedLogin? {
+    fun get(id: String): Login? {
         return readQueryCounters.measure {
             store.get(id)
         }
@@ -60,44 +61,44 @@ class DatabaseLoginsStorage(dbPath: String) : AutoCloseable {
     }
 
     @Throws(LoginsApiException::class)
-    fun list(): List<EncryptedLogin> {
+    fun list(): List<Login> {
         return readQueryCounters.measure {
             store.list()
         }
     }
 
     @Throws(LoginsApiException::class)
-    fun getByBaseDomain(baseDomain: String): List<EncryptedLogin> {
+    fun getByBaseDomain(baseDomain: String): List<Login> {
         return readQueryCounters.measure {
             store.getByBaseDomain(baseDomain)
         }
     }
 
     @Throws(LoginsApiException::class)
-    fun findLoginToUpdate(look: LoginEntry, encryptionKey: String): Login? {
+    fun findLoginToUpdate(look: LoginEntry): Login? {
         return readQueryCounters.measure {
-            store.findLoginToUpdate(look, encryptionKey)
+            store.findLoginToUpdate(look)
         }
     }
 
     @Throws(LoginsApiException::class)
-    fun add(entry: LoginEntry, encryptionKey: String): EncryptedLogin {
+    fun add(entry: LoginEntry): Login {
         return writeQueryCounters.measure {
-            store.add(entry, encryptionKey)
+            store.add(entry)
         }
     }
 
     @Throws(LoginsApiException::class)
-    fun update(id: String, entry: LoginEntry, encryptionKey: String): EncryptedLogin {
+    fun update(id: String, entry: LoginEntry): Login {
         return writeQueryCounters.measure {
-            store.update(id, entry, encryptionKey)
+            store.update(id, entry)
         }
     }
 
     @Throws(LoginsApiException::class)
-    fun addOrUpdate(entry: LoginEntry, encryptionKey: String): EncryptedLogin {
+    fun addOrUpdate(entry: LoginEntry): Login {
         return writeQueryCounters.measure {
-            store.addOrUpdate(entry, encryptionKey)
+            store.addOrUpdate(entry)
         }
     }
 

--- a/components/logins/android/src/test/java/mozilla/appservices/logins/DatabaseLoginsStorageTest.kt
+++ b/components/logins/android/src/test/java/mozilla/appservices/logins/DatabaseLoginsStorageTest.kt
@@ -32,13 +32,14 @@ class DatabaseLoginsStorageTest {
     @get:Rule
     val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
+    protected val encryptionKey = createKey()
+
     fun createTestStore(): DatabaseLoginsStorage {
         Megazord.init()
         val dbPath = dbFolder.newFile()
-        return DatabaseLoginsStorage(dbPath = dbPath.absolutePath)
+        val keyManager = createStaticKeyManager(key = encryptionKey)
+        return DatabaseLoginsStorage(dbPath = dbPath.absolutePath, keyManager = keyManager)
     }
-
-    protected val encryptionKey = createKey()
 
     protected fun getTestStore(): DatabaseLoginsStorage {
         val store = createTestStore()
@@ -57,7 +58,6 @@ class DatabaseLoginsStorageTest {
                     password = "hunter2",
                 ),
             ),
-            encryptionKey,
         )
 
         store.add(
@@ -74,7 +74,6 @@ class DatabaseLoginsStorageTest {
                     username = "Foobar2000",
                 ),
             ),
-            encryptionKey,
         )
 
         return store
@@ -106,7 +105,6 @@ class DatabaseLoginsStorageTest {
                     password = "hunter2",
                 ),
             ),
-            encryptionKey,
         )
 
         assertEquals(LoginsStoreMetrics.writeQueryCount.testGetValue(), 1)
@@ -128,7 +126,7 @@ class DatabaseLoginsStorageTest {
         )
 
         try {
-            store.add(invalid, encryptionKey)
+            store.add(invalid)
             fail("Should have thrown")
         } catch (e: LoginsApiException.InvalidRecord) {
             // All good.

--- a/components/logins/ios/Logins/LoginsStorage.swift
+++ b/components/logins/ios/Logins/LoginsStorage.swift
@@ -17,8 +17,8 @@ open class LoginsStorage {
     private var store: LoginStore
     private let queue = DispatchQueue(label: "com.mozilla.logins-storage")
 
-    public init(databasePath: String) throws {
-        store = try LoginStore(path: databasePath)
+    public init(databasePath: String, keyManager: KeyManager) throws {
+        store = try LoginStore(path: databasePath, encdec: createManagedEncdec(keyManager: keyManager))
     }
 
     open func wipeLocal() throws {
@@ -47,36 +47,36 @@ open class LoginsStorage {
     /// then this throws `LoginStoreError.DuplicateGuid` if there is a collision
     ///
     /// Returns the `id` of the newly inserted record.
-    open func add(login: LoginEntry, encryptionKey: String) throws -> EncryptedLogin {
+    open func add(login: LoginEntry) throws -> Login {
         return try queue.sync {
-            try self.store.add(login: login, encryptionKey: encryptionKey)
+            try self.store.add(login: login)
         }
     }
 
     /// Update `login` in the database. If `login.id` does not refer to a known
     /// login, then this throws `LoginStoreError.NoSuchRecord`.
-    open func update(id: String, login: LoginEntry, encryptionKey: String) throws -> EncryptedLogin {
+    open func update(id: String, login: LoginEntry) throws -> Login {
         return try queue.sync {
-            try self.store.update(id: id, login: login, encryptionKey: encryptionKey)
+            try self.store.update(id: id, login: login)
         }
     }
 
     /// Get the record with the given id. Returns nil if there is no such record.
-    open func get(id: String) throws -> EncryptedLogin? {
+    open func get(id: String) throws -> Login? {
         return try queue.sync {
             try self.store.get(id: id)
         }
     }
 
     /// Get the entire list of records.
-    open func list() throws -> [EncryptedLogin] {
+    open func list() throws -> [Login] {
         return try queue.sync {
             try self.store.list()
         }
     }
 
     /// Get the list of records for some base domain.
-    open func getByBaseDomain(baseDomain: String) throws -> [EncryptedLogin] {
+    open func getByBaseDomain(baseDomain: String) throws -> [Login] {
         return try queue.sync {
             try self.store.getByBaseDomain(baseDomain: baseDomain)
         }

--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -223,13 +223,9 @@ impl LoginDb {
         Ok(logins
             // First, try to match the username
             .iter()
-            .find(|login| login.sec_fields.username == look.sec_fields.username)
+            .find(|login| login.username == look.username)
             // Fall back on a blank username
-            .or_else(|| {
-                logins
-                    .iter()
-                    .find(|login| login.sec_fields.username.is_empty())
-            })
+            .or_else(|| logins.iter().find(|login| login.username.is_empty()))
             // Clone the login to avoid ref issues when returning across the FFI
             .cloned())
     }
@@ -364,6 +360,10 @@ impl LoginDb {
         let now_ms = util::system_time_ms_i64(SystemTime::now());
 
         let new_entry = self.fixup_and_check_for_dupes(&guid, entry, encdec)?;
+        let sec_fields = SecureLoginFields {
+            username: new_entry.username,
+            password: new_entry.password,
+        };
         let result = EncryptedLogin {
             record: RecordFields {
                 id: guid.to_string(),
@@ -372,8 +372,14 @@ impl LoginDb {
                 time_last_used: now_ms,
                 times_used: 1,
             },
-            fields: new_entry.fields,
-            sec_fields: new_entry.sec_fields.encrypt(encdec)?,
+            fields: LoginFields {
+                origin: new_entry.origin,
+                form_action_origin: new_entry.form_action_origin,
+                http_realm: new_entry.http_realm,
+                username_field: new_entry.username_field,
+                password_field: new_entry.password_field,
+            },
+            sec_fields: sec_fields.encrypt(encdec)?,
         };
         let tx = self.unchecked_transaction()?;
         self.insert_new_login(&result)?;
@@ -402,8 +408,8 @@ impl LoginDb {
             // Try to detect if sync is enabled by checking if there are any mirror logins
             let has_mirror_row: bool =
                 self.db.query_one("SELECT EXISTS (SELECT 1 FROM loginsM)")?;
-            let has_http_realm = entry.fields.http_realm.is_some();
-            let has_form_action_origin = entry.fields.form_action_origin.is_some();
+            let has_http_realm = entry.http_realm.is_some();
+            let has_form_action_origin = entry.form_action_origin.is_some();
             report_error!(
                 "logins-duplicate-in-update",
                 "(mirror: {has_mirror_row}, realm: {has_http_realm}, form_origin: {has_form_action_origin})");
@@ -415,27 +421,36 @@ impl LoginDb {
 
         // We must read the existing record so we can correctly manage timePasswordChanged.
         let existing = match self.get_by_id(sguid)? {
-            Some(e) => e,
+            Some(e) => e.decrypt(encdec)?,
             None => return Err(Error::NoSuchRecord(sguid.to_owned())),
         };
-        let time_password_changed =
-            if existing.decrypt_fields(encdec)?.password == entry.sec_fields.password {
-                existing.record.time_password_changed
-            } else {
-                now_ms
-            };
+        let time_password_changed = if existing.password == entry.password {
+            existing.time_password_changed
+        } else {
+            now_ms
+        };
 
         // Make the final object here - every column will be updated.
+        let sec_fields = SecureLoginFields {
+            username: entry.username,
+            password: entry.password,
+        };
         let result = EncryptedLogin {
             record: RecordFields {
-                id: existing.record.id,
-                time_created: existing.record.time_created,
+                id: existing.id,
+                time_created: existing.time_created,
                 time_password_changed,
                 time_last_used: now_ms,
-                times_used: existing.record.times_used + 1,
+                times_used: existing.times_used + 1,
             },
-            fields: entry.fields,
-            sec_fields: entry.sec_fields.encrypt(encdec)?,
+            fields: LoginFields {
+                origin: entry.origin,
+                form_action_origin: entry.form_action_origin,
+                http_realm: entry.http_realm,
+                username_field: entry.username_field,
+                password_field: entry.password_field,
+            },
+            sec_fields: sec_fields.encrypt(encdec)?,
         };
 
         self.update_existing_login(&result)?;
@@ -451,7 +466,7 @@ impl LoginDb {
         // Make sure to fixup the entry first, in case that changes the username
         let entry = entry.fixup()?;
         match self.find_login_to_update(entry.clone(), encdec)? {
-            Some(login) => self.update(&login.record.id, entry, encdec),
+            Some(login) => self.update(&login.id, entry, encdec),
             None => self.add(entry, encdec),
         }
     }
@@ -497,7 +512,7 @@ impl LoginDb {
         for possible in self.get_by_entry_target(entry)? {
             if possible.guid() != *guid {
                 let pos_sec_fields = possible.decrypt_fields(encdec)?;
-                if pos_sec_fields.username == entry.sec_fields.username {
+                if pos_sec_fields.username == entry.username {
                     return Ok(Some(possible.guid()));
                 }
             }
@@ -546,13 +561,10 @@ impl LoginDb {
                 common_cols = schema::COMMON_COLS
             );
         }
-        match (
-            entry.fields.form_action_origin.as_ref(),
-            entry.fields.http_realm.as_ref(),
-        ) {
+        match (entry.form_action_origin.as_ref(), entry.http_realm.as_ref()) {
             (Some(form_action_origin), None) => {
                 let params = named_params! {
-                    ":origin": &entry.fields.origin,
+                    ":origin": &entry.origin,
                     ":form_action_origin": form_action_origin,
                 };
                 self.db
@@ -562,7 +574,7 @@ impl LoginDb {
             }
             (None, Some(http_realm)) => {
                 let params = named_params! {
-                    ":origin": &entry.fields.origin,
+                    ":origin": &entry.origin,
                     ":http_realm": http_realm,
                 };
                 self.db
@@ -885,21 +897,16 @@ mod tests {
     use super::*;
     use crate::encryption::test_utils::TEST_ENCDEC;
     use crate::sync::merge::LocalLogin;
-    use crate::SecureLoginFields;
     use std::{thread, time};
 
     #[test]
     fn test_username_dupe_semantics() {
         let mut login = LoginEntry {
-            fields: LoginFields {
-                origin: "https://www.example.com".into(),
-                http_realm: Some("https://www.example.com".into()),
-                ..LoginFields::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "sekret".into(),
-            },
+            origin: "https://www.example.com".into(),
+            http_realm: Some("https://www.example.com".into()),
+            username: "test".into(),
+            password: "sekret".into(),
+            ..LoginEntry::default()
         };
 
         let db = LoginDb::open_in_memory().unwrap();
@@ -916,7 +923,7 @@ mod tests {
         );
 
         // Add one with an empty username - not a dupe.
-        login.sec_fields.username = "".to_string();
+        login.username = "".to_string();
         db.add(login.clone(), &*TEST_ENCDEC)
             .expect("empty login isn't a dupe");
 
@@ -935,17 +942,13 @@ mod tests {
         let added = db
             .add(
                 LoginEntry {
-                    fields: LoginFields {
-                        form_action_origin: Some("http://😍.com".into()),
-                        origin: "http://😍.com".into(),
-                        http_realm: None,
-                        username_field: "😍".into(),
-                        password_field: "😍".into(),
-                    },
-                    sec_fields: SecureLoginFields {
-                        username: "😍".into(),
-                        password: "😍".into(),
-                    },
+                    form_action_origin: Some("http://😍.com".into()),
+                    origin: "http://😍.com".into(),
+                    http_realm: None,
+                    username_field: "😍".into(),
+                    password_field: "😍".into(),
+                    username: "😍".into(),
+                    password: "😍".into(),
                 },
                 &*TEST_ENCDEC,
             )
@@ -973,16 +976,12 @@ mod tests {
         let added = db
             .add(
                 LoginEntry {
-                    fields: LoginFields {
-                        form_action_origin: None,
-                        origin: "http://😍.com".into(),
-                        http_realm: Some("😍😍".into()),
-                        ..Default::default()
-                    },
-                    sec_fields: SecureLoginFields {
-                        username: "😍".into(),
-                        password: "😍".into(),
-                    },
+                    form_action_origin: None,
+                    origin: "http://😍.com".into(),
+                    http_realm: Some("😍😍".into()),
+                    username: "😍".into(),
+                    password: "😍".into(),
+                    ..Default::default()
                 },
                 &*TEST_ENCDEC,
             )
@@ -1019,15 +1018,10 @@ mod tests {
         for h in good.iter().chain(bad.iter()) {
             db.add(
                 LoginEntry {
-                    fields: LoginFields {
-                        origin: (*h).into(),
-                        http_realm: Some((*h).into()),
-                        ..Default::default()
-                    },
-                    sec_fields: SecureLoginFields {
-                        password: "test".into(),
-                        ..Default::default()
-                    },
+                    origin: (*h).into(),
+                    http_realm: Some((*h).into()),
+                    password: "test".into(),
+                    ..Default::default()
                 },
                 &*TEST_ENCDEC,
             )
@@ -1108,15 +1102,11 @@ mod tests {
     fn test_add() {
         let db = LoginDb::open_in_memory().unwrap();
         let to_add = LoginEntry {
-            fields: LoginFields {
-                origin: "https://www.example.com".into(),
-                http_realm: Some("https://www.example.com".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test_user".into(),
-                password: "test_password".into(),
-            },
+            origin: "https://www.example.com".into(),
+            http_realm: Some("https://www.example.com".into()),
+            username: "test_user".into(),
+            password: "test_password".into(),
+            ..Default::default()
         };
         let login = db.add(to_add, &*TEST_ENCDEC).unwrap();
         let login2 = db.get_by_id(&login.record.id).unwrap().unwrap();
@@ -1132,15 +1122,11 @@ mod tests {
         let login = db
             .add(
                 LoginEntry {
-                    fields: LoginFields {
-                        origin: "https://www.example.com".into(),
-                        http_realm: Some("https://www.example.com".into()),
-                        ..Default::default()
-                    },
-                    sec_fields: SecureLoginFields {
-                        username: "user1".into(),
-                        password: "password1".into(),
-                    },
+                    origin: "https://www.example.com".into(),
+                    http_realm: Some("https://www.example.com".into()),
+                    username: "user1".into(),
+                    password: "password1".into(),
+                    ..Default::default()
                 },
                 &*TEST_ENCDEC,
             )
@@ -1148,15 +1134,12 @@ mod tests {
         db.update(
             &login.record.id,
             LoginEntry {
-                fields: LoginFields {
-                    origin: "https://www.example2.com".into(),
-                    http_realm: Some("https://www.example2.com".into()),
-                    ..login.fields
-                },
-                sec_fields: SecureLoginFields {
-                    username: "user2".into(),
-                    password: "password2".into(),
-                },
+                origin: "https://www.example2.com".into(),
+                http_realm: Some("https://www.example2.com".into()),
+                username: "user2".into(),
+                password: "password2".into(),
+                ..Default::default()
+                // TODO: check and fix if needed
             },
             &*TEST_ENCDEC,
         )
@@ -1180,15 +1163,11 @@ mod tests {
         let login = db
             .add(
                 LoginEntry {
-                    fields: LoginFields {
-                        origin: "https://www.example.com".into(),
-                        http_realm: Some("https://www.example.com".into()),
-                        ..Default::default()
-                    },
-                    sec_fields: SecureLoginFields {
-                        username: "user1".into(),
-                        password: "password1".into(),
-                    },
+                    origin: "https://www.example.com".into(),
+                    http_realm: Some("https://www.example.com".into()),
+                    username: "user1".into(),
+                    password: "password1".into(),
+                    ..Default::default()
                 },
                 &*TEST_ENCDEC,
             )
@@ -1207,15 +1186,11 @@ mod tests {
         let login = db
             .add(
                 LoginEntry {
-                    fields: LoginFields {
-                        origin: "https://www.example.com".into(),
-                        http_realm: Some("https://www.example.com".into()),
-                        ..Default::default()
-                    },
-                    sec_fields: SecureLoginFields {
-                        username: "test_user".into(),
-                        password: "test_password".into(),
-                    },
+                    origin: "https://www.example.com".into(),
+                    http_realm: Some("https://www.example.com".into()),
+                    username: "test_user".into(),
+                    password: "test_password".into(),
+                    ..Default::default()
                 },
                 &*TEST_ENCDEC,
             )
@@ -1241,15 +1216,11 @@ mod tests {
 
         fn make_entry(username: &str, password: &str) -> LoginEntry {
             LoginEntry {
-                fields: LoginFields {
-                    origin: "https://www.example.com".into(),
-                    http_realm: Some("the website".into()),
-                    ..Default::default()
-                },
-                sec_fields: SecureLoginFields {
-                    username: username.into(),
-                    password: password.into(),
-                },
+                origin: "https://www.example.com".into(),
+                http_realm: Some("the website".into()),
+                username: username.into(),
+                password: password.into(),
+                ..Default::default()
             }
         }
 
@@ -1279,15 +1250,11 @@ mod tests {
             // Non-match because the http_realm is different
             db.add(
                 LoginEntry {
-                    fields: LoginFields {
-                        origin: "https://www.example.com".into(),
-                        http_realm: Some("the other website".into()),
-                        ..Default::default()
-                    },
-                    sec_fields: SecureLoginFields {
-                        username: "user".into(),
-                        password: "pass".into(),
-                    },
+                    origin: "https://www.example.com".into(),
+                    http_realm: Some("the other website".into()),
+                    username: "user".into(),
+                    password: "pass".into(),
+                    ..Default::default()
                 },
                 &*TEST_ENCDEC,
             )
@@ -1295,15 +1262,11 @@ mod tests {
             // Non-match because it uses form_action_origin instead of http_realm
             db.add(
                 LoginEntry {
-                    fields: LoginFields {
-                        origin: "https://www.example.com".into(),
-                        form_action_origin: Some("https://www.example.com/".into()),
-                        ..Default::default()
-                    },
-                    sec_fields: SecureLoginFields {
-                        username: "user".into(),
-                        password: "pass".into(),
-                    },
+                    origin: "https://www.example.com".into(),
+                    form_action_origin: Some("https://www.example.com/".into()),
+                    username: "user".into(),
+                    password: "pass".into(),
+                    ..Default::default()
                 },
                 &*TEST_ENCDEC,
             )
@@ -1344,11 +1307,8 @@ mod tests {
             assert!(db
                 .find_login_to_update(
                     LoginEntry {
-                        fields: LoginFields {
-                            http_realm: None,
-                            form_action_origin: None,
-                            ..LoginFields::default()
-                        },
+                        http_realm: None,
+                        form_action_origin: None,
                         ..LoginEntry::default()
                     },
                     &*TEST_ENCDEC
@@ -1367,11 +1327,11 @@ mod tests {
             db.insert_new_login(&dupe).unwrap();
 
             let mut entry = login.entry();
-            entry.sec_fields.password = "pass2".to_string();
-            db.update(&login.record.id, entry, &*TEST_ENCDEC).unwrap();
+            entry.password = "pass2".to_string();
+            db.update(&login.id, entry, &*TEST_ENCDEC).unwrap();
 
             let mut entry = login.entry();
-            entry.sec_fields.password = "pass3".to_string();
+            entry.password = "pass3".to_string();
             db.add_or_update(entry, &*TEST_ENCDEC).unwrap();
         }
     }

--- a/components/logins/src/encryption.rs
+++ b/components/logins/src/encryption.rs
@@ -26,24 +26,154 @@
 // multiple layers, from the app saying "sync now" all the way down to the
 // low level sync code.
 // To make life a little easier, we do that via a struct.
+//
+// Consumers of the Login component have 3 options for setting up encryption:
+//    1. Implement EncryptorDecryptor directly
+//       eg `LoginStore::new(MyEncryptorDecryptor)`
+//    2. Implement KeyManager and use ManagedEncryptorDecryptor
+//       eg `LoginStore::new(ManagedEncryptorDecryptor::new(MyKeyManager))`
+//    3. Generate a single key and create a StaticKeyManager and use it together with
+//       ManagedEncryptorDecryptor
+//       eg `LoginStore::new(ManagedEncryptorDecryptor::new(StaticKeyManager { key: myKey }))`
+//
+//  You can implement EncryptorDecryptor directly to keep full control over the encryption
+//  algorithm. For example, on the desktop, this could make use of NSS's SecretDecoderRing to
+//  achieve transparent key management.
+//
+//  If the application wants to keep the current encryption, like Android and iOS, for example, but
+//  control the key management itself, the KeyManager can be implemented and the encryption can be
+//  done on the Rust side with the ManagedEncryptorDecryptor.
+//
+//  In tests or some command line tools, it can be practical to use a static key that does not
+//  change at runtime and is already present when the LoginsStore is initialized. In this case, it
+//  makes sense to use the provided StaticKeyManager.
 
 use crate::error::*;
+use std::sync::Arc;
 
-pub type EncryptorDecryptor = jwcrypto::EncryptorDecryptor<Error>;
+/// This is the generic EncryptorDecryptor trait, as handed over to the Store during initialization.
+/// Consumers can implement either this generic trait and bring in their own crypto, or leverage the
+/// ManagedEncryptorDecryptor below, which provides encryption algorithms out of the box.
+///
+/// Note that EncryptorDecryptor must not call any LoginStore methods. The login store can call out
+/// to the EncryptorDecryptor when it's internal mutex is held so calling back in to the LoginStore
+/// may deadlock.
+pub trait EncryptorDecryptor: Send + Sync {
+    fn encrypt(&self, cleartext: Vec<u8>) -> ApiResult<Vec<u8>>;
+    fn decrypt(&self, ciphertext: Vec<u8>) -> ApiResult<Vec<u8>>;
+}
 
-#[handle_error(Error)]
-pub fn create_canary(text: &str, key: &str) -> ApiResult<String> {
-    EncryptorDecryptor::new(key)?.create_canary(text)
+impl<T: EncryptorDecryptor> EncryptorDecryptor for Arc<T> {
+    fn encrypt(&self, clearbytes: Vec<u8>) -> ApiResult<Vec<u8>> {
+        (**self).encrypt(clearbytes)
+    }
+
+    fn decrypt(&self, cipherbytes: Vec<u8>) -> ApiResult<Vec<u8>> {
+        (**self).decrypt(cipherbytes)
+    }
+}
+
+/// The ManagedEncryptorDecryptor makes use of the NSS provided cryptographic algorithms. The
+/// ManagedEncryptorDecryptor uses a KeyManager for encryption key retrieval.
+pub struct ManagedEncryptorDecryptor {
+    key_manager: Arc<dyn KeyManager>,
+}
+
+impl ManagedEncryptorDecryptor {
+    pub fn new(key_manager: Arc<dyn KeyManager>) -> Self {
+        Self { key_manager }
+    }
+}
+
+impl EncryptorDecryptor for ManagedEncryptorDecryptor {
+    fn encrypt(&self, clearbytes: Vec<u8>) -> ApiResult<Vec<u8>> {
+        let keybytes = self
+            .key_manager
+            .get_key()
+            .map_err(|_| LoginsApiError::MissingKey)?;
+        let key = std::str::from_utf8(&keybytes).map_err(|_| LoginsApiError::InvalidKey)?;
+
+        let encdec = jwcrypto::EncryptorDecryptor::new(key)
+            .map_err(|_: jwcrypto::EncryptorDecryptorError| LoginsApiError::InvalidKey)?;
+
+        let cleartext =
+            std::str::from_utf8(&clearbytes).map_err(|e| LoginsApiError::EncryptionFailed {
+                reason: e.to_string(),
+            })?;
+        encdec
+            .encrypt(cleartext, "encrypt SecureLoginFields")
+            .map_err(
+                |e: jwcrypto::EncryptorDecryptorError| LoginsApiError::EncryptionFailed {
+                    reason: e.to_string(),
+                },
+            )
+            .map(|text| text.into())
+    }
+
+    fn decrypt(&self, cipherbytes: Vec<u8>) -> ApiResult<Vec<u8>> {
+        let keybytes = self
+            .key_manager
+            .get_key()
+            .map_err(|_| LoginsApiError::MissingKey)?;
+        let key = std::str::from_utf8(&keybytes).map_err(|_| LoginsApiError::InvalidKey)?;
+
+        let encdec = jwcrypto::EncryptorDecryptor::new(key)
+            .map_err(|_: jwcrypto::EncryptorDecryptorError| LoginsApiError::InvalidKey)?;
+
+        let ciphertext =
+            std::str::from_utf8(&cipherbytes).map_err(|e| LoginsApiError::DecryptionFailed {
+                reason: e.to_string(),
+            })?;
+        encdec
+            .decrypt(ciphertext, "decrypt SecureLoginFields")
+            .map_err(
+                |e: jwcrypto::EncryptorDecryptorError| LoginsApiError::DecryptionFailed {
+                    reason: e.to_string(),
+                },
+            )
+            .map(|text| text.into())
+    }
+}
+
+/// Consumers can implement the KeyManager in combination with the ManagedEncryptorDecryptor to hand
+/// over the encryption key whenever encryption or decryption happens.
+pub trait KeyManager: Send + Sync {
+    fn get_key(&self) -> ApiResult<Vec<u8>>;
+}
+
+/// Last but not least we provide a StaticKeyManager, which can be
+/// used in cases where there is a single key during runtime, for example in tests.
+pub struct StaticKeyManager {
+    key: String,
+}
+
+impl StaticKeyManager {
+    pub fn new(key: String) -> Self {
+        Self { key }
+    }
+}
+
+impl KeyManager for StaticKeyManager {
+    #[handle_error(Error)]
+    fn get_key(&self) -> ApiResult<Vec<u8>> {
+        Ok(self.key.as_bytes().into())
+    }
 }
 
 #[handle_error(Error)]
+pub fn create_canary(text: &str, key: &str) -> ApiResult<String> {
+    jwcrypto::EncryptorDecryptor::new(key)?.create_canary(text)
+}
+
 pub fn check_canary(canary: &str, text: &str, key: &str) -> ApiResult<bool> {
-    EncryptorDecryptor::new(key)?.check_canary(canary, text)
+    let encdec = jwcrypto::EncryptorDecryptor::new(key)
+        .map_err(|_: jwcrypto::EncryptorDecryptorError| LoginsApiError::InvalidKey)?;
+    Ok(encdec.check_canary(canary, text).unwrap_or(false))
 }
 
 #[handle_error(Error)]
 pub fn create_key() -> ApiResult<String> {
-    EncryptorDecryptor::create_key()
+    jwcrypto::EncryptorDecryptor::create_key()
 }
 
 #[cfg(test)]
@@ -53,23 +183,17 @@ pub mod test_utils {
 
     lazy_static::lazy_static! {
         pub static ref TEST_ENCRYPTION_KEY: String = serde_json::to_string(&jwcrypto::Jwk::new_direct_key(Some("test-key".to_string())).unwrap()).unwrap();
-        pub static ref TEST_ENCRYPTOR: EncryptorDecryptor = EncryptorDecryptor::new(&TEST_ENCRYPTION_KEY).unwrap();
+        pub static ref TEST_ENCDEC: Arc<ManagedEncryptorDecryptor> = Arc::new(ManagedEncryptorDecryptor::new(Arc::new(StaticKeyManager { key: TEST_ENCRYPTION_KEY.clone() })));
     }
-    pub fn encrypt(value: &str) -> String {
-        TEST_ENCRYPTOR.encrypt(value, "test encrypt").unwrap()
-    }
-    pub fn decrypt(value: &str) -> String {
-        TEST_ENCRYPTOR.decrypt(value, "test decrypt").unwrap()
-    }
+
     pub fn encrypt_struct<T: Serialize>(fields: &T) -> String {
-        TEST_ENCRYPTOR
-            .encrypt_struct(fields, "test encrypt struct")
-            .unwrap()
+        let string = serde_json::to_string(fields).unwrap();
+        let cipherbytes = TEST_ENCDEC.encrypt(string.as_bytes().into()).unwrap();
+        std::str::from_utf8(&cipherbytes).unwrap().to_owned()
     }
     pub fn decrypt_struct<T: DeserializeOwned>(ciphertext: String) -> T {
-        TEST_ENCRYPTOR
-            .decrypt_struct(&ciphertext, "test decrypt struct")
-            .unwrap()
+        let jsonbytes = TEST_ENCDEC.decrypt(ciphertext.as_bytes().into()).unwrap();
+        serde_json::from_str(std::str::from_utf8(&jsonbytes).unwrap()).unwrap()
     }
 }
 
@@ -78,22 +202,65 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_encrypt() {
-        let ed = EncryptorDecryptor::new(&create_key().unwrap()).unwrap();
-        let cleartext = "secret";
-        let ciphertext = ed.encrypt(cleartext, "test encrypt").unwrap();
-        assert_eq!(ed.decrypt(&ciphertext, "test decrypt").unwrap(), cleartext);
-        let ed2 = EncryptorDecryptor::new(&create_key().unwrap()).unwrap();
+    fn test_static_key_manager() {
+        let key = create_key().unwrap();
+        let key_manager = StaticKeyManager { key: key.clone() };
+        assert_eq!(key.as_bytes(), key_manager.get_key().unwrap());
+    }
+
+    #[test]
+    fn test_managed_encdec_with_invalid_key() {
+        let key_manager = Arc::new(StaticKeyManager {
+            key: "bad_key".to_owned(),
+        });
+        let encdec = ManagedEncryptorDecryptor { key_manager };
         assert!(matches!(
-            ed2.decrypt(&ciphertext, "test decrypt").err().unwrap(),
-            Error::CryptoError(jwcrypto::EncryptorDecryptorError { description, .. })
-            if description == "test decrypt"
+            encdec.encrypt("secret".as_bytes().into()).err().unwrap(),
+            LoginsApiError::InvalidKey
+        ));
+    }
+
+    #[test]
+    fn test_managed_encdec_with_missing_key() {
+        struct MyKeyManager {}
+        impl KeyManager for MyKeyManager {
+            fn get_key(&self) -> ApiResult<Vec<u8>> {
+                Err(LoginsApiError::MissingKey)
+            }
+        }
+        let key_manager = Arc::new(MyKeyManager {});
+        let encdec = ManagedEncryptorDecryptor { key_manager };
+        assert!(matches!(
+            encdec.encrypt("secret".as_bytes().into()).err().unwrap(),
+            LoginsApiError::MissingKey
+        ));
+    }
+
+    #[test]
+    fn test_managed_encdec() {
+        let key = create_key().unwrap();
+        let key_manager = Arc::new(StaticKeyManager { key });
+        let encdec = ManagedEncryptorDecryptor { key_manager };
+        let cleartext = "secret";
+        let ciphertext = encdec.encrypt(cleartext.as_bytes().into()).unwrap();
+        assert_eq!(
+            encdec.decrypt(ciphertext.clone()).unwrap(),
+            cleartext.as_bytes()
+        );
+        let other_encdec = ManagedEncryptorDecryptor {
+            key_manager: Arc::new(StaticKeyManager {
+                key: create_key().unwrap(),
+            }),
+        };
+        assert!(matches!(
+            other_encdec.decrypt(ciphertext).err().unwrap(),
+            LoginsApiError::DecryptionFailed { reason: _ }
         ));
     }
 
     #[test]
     fn test_key_error() {
-        let storage_err = EncryptorDecryptor::new("bad-key").err().unwrap();
+        let storage_err = jwcrypto::EncryptorDecryptor::new("bad-key").err().unwrap();
         assert!(matches!(
             storage_err,
             Error::CryptoError(jwcrypto::EncryptorDecryptorError {
@@ -111,11 +278,12 @@ mod test {
         assert!(check_canary(&canary, CANARY_TEXT, &key).unwrap());
 
         let different_key = create_key().unwrap();
+        assert!(!check_canary(&canary, CANARY_TEXT, &different_key).unwrap());
+
+        let bad_key = "bad_key".to_owned();
         assert!(matches!(
-            check_canary(&canary, CANARY_TEXT, &different_key)
-                .err()
-                .unwrap(),
-            LoginsApiError::IncorrectKey
+            check_canary(&canary, CANARY_TEXT, &bad_key).err().unwrap(),
+            LoginsApiError::InvalidKey
         ));
     }
 }

--- a/components/logins/src/login.rs
+++ b/components/logins/src/login.rs
@@ -294,7 +294,82 @@ pub struct LoginFields {
     pub password_field: String,
 }
 
-impl LoginFields {
+/// LoginEntry fields that are stored encrypted
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct SecureLoginFields {
+    // - Username cannot be null, use the empty string instead
+    // - Password can't be empty or null (enforced in the ValidateAndFixup code)
+    //
+    // This matches the desktop behavior:
+    // https://searchfox.org/mozilla-central/rev/d3683dbb252506400c71256ef3994cdbdfb71ada/toolkit/components/passwordmgr/LoginManager.jsm#260-267
+
+    // Because we store the json version of this in the DB, and that's the only place the json
+    // is used, we rename the fields to short names, just to reduce the overhead in the DB.
+    #[serde(rename = "u")]
+    pub username: String,
+    #[serde(rename = "p")]
+    pub password: String,
+}
+
+impl SecureLoginFields {
+    pub fn encrypt(&self, encdec: &dyn EncryptorDecryptor) -> Result<String> {
+        let string = serde_json::to_string(&self)?;
+        let cipherbytes = encdec
+            .encrypt(string.as_bytes().into())
+            .map_err(|e| Error::EncryptionFailed(e.to_string()))?;
+        let ciphertext = std::str::from_utf8(&cipherbytes)
+            .map_err(|e| Error::EncryptionFailed(e.to_string()))?;
+        Ok(ciphertext.to_owned())
+    }
+
+    pub fn decrypt(ciphertext: &str, encdec: &dyn EncryptorDecryptor) -> Result<Self> {
+        let jsonbytes = encdec
+            .decrypt(ciphertext.as_bytes().into())
+            .map_err(|e| Error::DecryptionFailed(e.to_string()))?;
+        let json =
+            std::str::from_utf8(&jsonbytes).map_err(|e| Error::DecryptionFailed(e.to_string()))?;
+        Ok(serde_json::from_str(json)?)
+    }
+}
+
+/// Login data specific to database records
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
+pub struct RecordFields {
+    pub id: String,
+    pub time_created: i64,
+    pub time_password_changed: i64,
+    pub time_last_used: i64,
+    pub times_used: i64,
+}
+
+/// A login handed over to the store API; ie a login not yet persisted
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
+pub struct LoginEntry {
+    // login fields
+    pub origin: String,
+    pub form_action_origin: Option<String>,
+    pub http_realm: Option<String>,
+    pub username_field: String,
+    pub password_field: String,
+
+    // secure fields
+    pub username: String,
+    pub password: String,
+}
+
+impl LoginEntry {
+    pub fn new(fields: LoginFields, sec_fields: SecureLoginFields) -> Self {
+        Self {
+            origin: fields.origin,
+            form_action_origin: fields.form_action_origin,
+            http_realm: fields.http_realm,
+            username_field: fields.username_field,
+            password_field: fields.password_field,
+
+            username: sec_fields.username,
+            password: sec_fields.password,
+        }
+    }
     /// Internal helper for validation and fixups of an "origin" stored as
     /// a string.
     fn validate_and_fixup_origin(origin: &str) -> Result<Option<String>> {
@@ -348,87 +423,88 @@ impl LoginFields {
     }
 }
 
-/// LoginEntry fields that are stored encrypted
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct SecureLoginFields {
-    // - Username cannot be null, use the empty string instead
-    // - Password can't be empty or null (enforced in the ValidateAndFixup code)
-    //
-    // This matches the desktop behavior:
-    // https://searchfox.org/mozilla-central/rev/d3683dbb252506400c71256ef3994cdbdfb71ada/toolkit/components/passwordmgr/LoginManager.jsm#260-267
-
-    // Because we store the json version of this in the DB, and that's the only place the json
-    // is used, we rename the fields to short names, just to reduce the overhead in the DB.
-    #[serde(rename = "u")]
-    pub username: String,
-    #[serde(rename = "p")]
-    pub password: String,
-}
-
-impl SecureLoginFields {
-    pub fn encrypt(&self, encdec: &dyn EncryptorDecryptor) -> Result<String> {
-        let string = serde_json::to_string(&self)?;
-        let cipherbytes = encdec
-            .encrypt(string.as_bytes().into())
-            .map_err(|e| Error::EncryptionFailed(e.to_string()))?;
-        let ciphertext = std::str::from_utf8(&cipherbytes)
-            .map_err(|e| Error::EncryptionFailed(e.to_string()))?;
-        Ok(ciphertext.to_owned())
-    }
-
-    pub fn decrypt(ciphertext: &str, encdec: &dyn EncryptorDecryptor) -> Result<Self> {
-        let jsonbytes = encdec
-            .decrypt(ciphertext.as_bytes().into())
-            .map_err(|e| Error::DecryptionFailed(e.to_string()))?;
-        let json =
-            std::str::from_utf8(&jsonbytes).map_err(|e| Error::DecryptionFailed(e.to_string()))?;
-        Ok(serde_json::from_str(json)?)
-    }
-}
-
-/// Login data specific to database records
+/// A login handed over from the store API, which has been persisted and contains persistence
+/// information such as id and time stamps
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
-pub struct RecordFields {
+pub struct Login {
+    // record fields
     pub id: String,
     pub time_created: i64,
     pub time_password_changed: i64,
     pub time_last_used: i64,
     pub times_used: i64,
-}
 
-/// A login entered by the user
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
-pub struct LoginEntry {
-    pub fields: LoginFields,
-    pub sec_fields: SecureLoginFields,
-}
+    // login fields
+    pub origin: String,
+    pub form_action_origin: Option<String>,
+    pub http_realm: Option<String>,
+    pub username_field: String,
+    pub password_field: String,
 
-/// A login stored in the database
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
-pub struct Login {
-    pub record: RecordFields,
-    pub fields: LoginFields,
-    pub sec_fields: SecureLoginFields,
+    // secure fields
+    pub username: String,
+    pub password: String,
 }
 
 impl Login {
+    pub fn new(record: RecordFields, fields: LoginFields, sec_fields: SecureLoginFields) -> Self {
+        Self {
+            id: record.id,
+            time_created: record.time_created,
+            time_password_changed: record.time_password_changed,
+            time_last_used: record.time_last_used,
+            times_used: record.times_used,
+
+            origin: fields.origin,
+            form_action_origin: fields.form_action_origin,
+            http_realm: fields.http_realm,
+            username_field: fields.username_field,
+            password_field: fields.password_field,
+
+            username: sec_fields.username,
+            password: sec_fields.password,
+        }
+    }
+
     #[inline]
     pub fn guid(&self) -> Guid {
-        Guid::from_string(self.record.id.clone())
+        Guid::from_string(self.id.clone())
     }
 
     pub fn entry(&self) -> LoginEntry {
         LoginEntry {
-            fields: self.fields.clone(),
-            sec_fields: self.sec_fields.clone(),
+            origin: self.origin.clone(),
+            form_action_origin: self.form_action_origin.clone(),
+            http_realm: self.http_realm.clone(),
+            username_field: self.username_field.clone(),
+            password_field: self.password_field.clone(),
+
+            username: self.username.clone(),
+            password: self.password.clone(),
         }
     }
 
     pub fn encrypt(self, encdec: &dyn EncryptorDecryptor) -> Result<EncryptedLogin> {
+        let sec_fields = SecureLoginFields {
+            username: self.username.clone(),
+            password: self.password.clone(),
+        };
         Ok(EncryptedLogin {
-            record: self.record,
-            fields: self.fields,
-            sec_fields: self.sec_fields.encrypt(encdec)?,
+            record: RecordFields {
+                id: self.id.clone(),
+                time_created: self.time_created.clone(),
+                time_password_changed: self.time_password_changed.clone(),
+                time_last_used: self.time_last_used.clone(),
+                times_used: self.times_used.clone(),
+            },
+            fields: LoginFields {
+                origin: self.origin.clone(),
+                form_action_origin: self.form_action_origin.clone(),
+                http_realm: self.http_realm.clone(),
+                username_field: self.username_field.clone(),
+                password_field: self.password_field.clone(),
+            },
+            sec_fields: sec_fields.encrypt(encdec)?,
         })
     }
 }
@@ -454,11 +530,11 @@ impl EncryptedLogin {
     }
 
     pub fn decrypt(self, encdec: &dyn EncryptorDecryptor) -> Result<Login> {
-        Ok(Login {
-            record: self.record,
-            fields: self.fields,
-            sec_fields: SecureLoginFields::decrypt(&self.sec_fields, encdec)?,
-        })
+        Ok(Login::new(
+            self.record,
+            self.fields,
+            SecureLoginFields::decrypt(&self.sec_fields, encdec)?,
+        ))
     }
 
     pub fn decrypt_fields(&self, encdec: &dyn EncryptorDecryptor) -> Result<SecureLoginFields> {
@@ -536,8 +612,7 @@ pub trait ValidateAndFixup {
         Self: Sized;
 }
 
-impl ValidateAndFixup for LoginFields {
-    /// Internal helper for doing validation and fixups.
+impl ValidateAndFixup for LoginEntry {
     fn validate_and_fixup(&self, fixup: bool) -> Result<Option<Self>> {
         // XXX TODO: we've definitely got more validation and fixups to add here!
 
@@ -662,13 +737,8 @@ impl ValidateAndFixup for LoginFields {
             }
         }
 
-        Ok(maybe_fixed)
-    }
-}
-
-impl ValidateAndFixup for SecureLoginFields {
-    /// We don't actually have fixups.
-    fn validate_and_fixup(&self, _fixup: bool) -> Result<Option<Self>> {
+        // secure fields
+        //
         // \r\n chars are valid in desktop for some reason, so we allow them here too.
         if self.username.contains('\0') {
             return Err(InvalidLogin::IllegalFieldValue {
@@ -685,26 +755,8 @@ impl ValidateAndFixup for SecureLoginFields {
             }
             .into());
         }
-        Ok(None)
-    }
-}
 
-impl ValidateAndFixup for LoginEntry {
-    fn validate_and_fixup(&self, fixup: bool) -> Result<Option<Self>> {
-        let new_fields = self.fields.validate_and_fixup(fixup)?;
-        let new_sec_fields = self.sec_fields.validate_and_fixup(fixup)?;
-        Ok(match (new_fields, new_sec_fields) {
-            (Some(fields), Some(sec_fields)) => Some(Self { fields, sec_fields }),
-            (Some(fields), None) => Some(Self {
-                fields,
-                sec_fields: self.sec_fields.clone(),
-            }),
-            (None, Some(sec_fields)) => Some(Self {
-                fields: self.fields.clone(),
-                sec_fields,
-            }),
-            (None, None) => None,
-        })
+        Ok(maybe_fixed)
     }
 }
 
@@ -754,7 +806,7 @@ mod tests {
             "file://",
             "https://[::1]",
         ] {
-            assert_eq!(LoginFields::validate_and_fixup_origin(input)?, None);
+            assert_eq!(LoginEntry::validate_and_fixup_origin(input)?, None);
         }
 
         // And URLs which get normalized.
@@ -786,7 +838,7 @@ mod tests {
             ),
         ] {
             assert_eq!(
-                LoginFields::validate_and_fixup_origin(input)?,
+                LoginEntry::validate_and_fixup_origin(input)?,
                 Some((*output).into())
             );
         }
@@ -803,257 +855,173 @@ mod tests {
         }
 
         let valid_login = LoginEntry {
-            fields: LoginFields {
-                origin: "https://www.example.com".into(),
-                http_realm: Some("https://www.example.com".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "test".into(),
-            },
+            origin: "https://www.example.com".into(),
+            http_realm: Some("https://www.example.com".into()),
+            username: "test".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let login_with_empty_origin = LoginEntry {
-            fields: LoginFields {
-                origin: "".into(),
-                http_realm: Some("https://www.example.com".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "test".into(),
-            },
+            origin: "".into(),
+            http_realm: Some("https://www.example.com".into()),
+            username: "test".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let login_with_empty_password = LoginEntry {
-            fields: LoginFields {
-                origin: "https://www.example.com".into(),
-                http_realm: Some("https://www.example.com".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "".into(),
-            },
+            origin: "https://www.example.com".into(),
+            http_realm: Some("https://www.example.com".into()),
+            username: "test".into(),
+            password: "".into(),
+            ..Default::default()
         };
 
         let login_with_form_submit_and_http_realm = LoginEntry {
-            fields: LoginFields {
-                origin: "https://www.example.com".into(),
-                http_realm: Some("https://www.example.com".into()),
-                form_action_origin: Some("https://www.example.com".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "".into(),
-                password: "test".into(),
-            },
+            origin: "https://www.example.com".into(),
+            http_realm: Some("https://www.example.com".into()),
+            form_action_origin: Some("https://www.example.com".into()),
+            username: "".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let login_without_form_submit_or_http_realm = LoginEntry {
-            fields: LoginFields {
-                origin: "https://www.example.com".into(),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "".into(),
-                password: "test".into(),
-            },
+            origin: "https://www.example.com".into(),
+            username: "".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let login_with_legacy_form_submit_and_http_realm = LoginEntry {
-            fields: LoginFields {
-                origin: "https://www.example.com".into(),
-                form_action_origin: Some("".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "".into(),
-                password: "test".into(),
-            },
+            origin: "https://www.example.com".into(),
+            form_action_origin: Some("".into()),
+            username: "".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let login_with_null_http_realm = LoginEntry {
-            fields: LoginFields {
-                origin: "https://www.example.com".into(),
-                http_realm: Some("https://www.example.\0com".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "test".into(),
-            },
+            origin: "https://www.example.com".into(),
+            http_realm: Some("https://www.example.\0com".into()),
+            username: "test".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let login_with_null_username = LoginEntry {
-            fields: LoginFields {
-                origin: "https://www.example.com".into(),
-                http_realm: Some("https://www.example.com".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "\0".into(),
-                password: "test".into(),
-            },
+            origin: "https://www.example.com".into(),
+            http_realm: Some("https://www.example.com".into()),
+            username: "\0".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let login_with_null_password = LoginEntry {
-            fields: LoginFields {
-                origin: "https://www.example.com".into(),
-                http_realm: Some("https://www.example.com".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "username".into(),
-                password: "test\0".into(),
-            },
+            origin: "https://www.example.com".into(),
+            http_realm: Some("https://www.example.com".into()),
+            username: "username".into(),
+            password: "test\0".into(),
+            ..Default::default()
         };
 
         let login_with_newline_origin = LoginEntry {
-            fields: LoginFields {
-                origin: "\rhttps://www.example.com".into(),
-                http_realm: Some("https://www.example.com".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "test".into(),
-            },
+            origin: "\rhttps://www.example.com".into(),
+            http_realm: Some("https://www.example.com".into()),
+            username: "test".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let login_with_newline_username_field = LoginEntry {
-            fields: LoginFields {
-                origin: "https://www.example.com".into(),
-                http_realm: Some("https://www.example.com".into()),
-                username_field: "\n".into(),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "test".into(),
-            },
+            origin: "https://www.example.com".into(),
+            http_realm: Some("https://www.example.com".into()),
+            username_field: "\n".into(),
+            username: "test".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let login_with_newline_realm = LoginEntry {
-            fields: LoginFields {
-                origin: "https://www.example.com".into(),
-                http_realm: Some("foo\nbar".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "test".into(),
-            },
+            origin: "https://www.example.com".into(),
+            http_realm: Some("foo\nbar".into()),
+            username: "test".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let login_with_newline_password = LoginEntry {
-            fields: LoginFields {
-                origin: "https://www.example.com".into(),
-                http_realm: Some("https://www.example.com".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "test\n".into(),
-            },
+            origin: "https://www.example.com".into(),
+            http_realm: Some("https://www.example.com".into()),
+            username: "test".into(),
+            password: "test\n".into(),
+            ..Default::default()
         };
 
         let login_with_period_username_field = LoginEntry {
-            fields: LoginFields {
-                origin: "https://www.example.com".into(),
-                http_realm: Some("https://www.example.com".into()),
-                username_field: ".".into(),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "test".into(),
-            },
+            origin: "https://www.example.com".into(),
+            http_realm: Some("https://www.example.com".into()),
+            username_field: ".".into(),
+            username: "test".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let login_with_period_form_action_origin = LoginEntry {
-            fields: LoginFields {
-                form_action_origin: Some(".".into()),
-                origin: "https://www.example.com".into(),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "test".into(),
-            },
+            form_action_origin: Some(".".into()),
+            origin: "https://www.example.com".into(),
+            username: "test".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let login_with_javascript_form_action_origin = LoginEntry {
-            fields: LoginFields {
-                form_action_origin: Some("javascript:".into()),
-                origin: "https://www.example.com".into(),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "test".into(),
-            },
+            form_action_origin: Some("javascript:".into()),
+            origin: "https://www.example.com".into(),
+            username: "test".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let login_with_malformed_origin_parens = LoginEntry {
-            fields: LoginFields {
-                origin: " (".into(),
-                http_realm: Some("https://www.example.com".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "test".into(),
-            },
+            origin: " (".into(),
+            http_realm: Some("https://www.example.com".into()),
+            username: "test".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let login_with_host_unicode = LoginEntry {
-            fields: LoginFields {
-                origin: "http://💖.com".into(),
-                http_realm: Some("https://www.example.com".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "test".into(),
-            },
+            origin: "http://💖.com".into(),
+            http_realm: Some("https://www.example.com".into()),
+            username: "test".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let login_with_origin_trailing_slash = LoginEntry {
-            fields: LoginFields {
-                origin: "https://www.example.com/".into(),
-                http_realm: Some("https://www.example.com".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "test".into(),
-            },
+            origin: "https://www.example.com/".into(),
+            http_realm: Some("https://www.example.com".into()),
+            username: "test".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let login_with_origin_expanded_ipv6 = LoginEntry {
-            fields: LoginFields {
-                origin: "https://[0:0:0:0:0:0:1:1]".into(),
-                http_realm: Some("https://www.example.com".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "test".into(),
-            },
+            origin: "https://[0:0:0:0:0:0:1:1]".into(),
+            http_realm: Some("https://www.example.com".into()),
+            username: "test".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let login_with_unknown_protocol = LoginEntry {
-            fields: LoginFields {
-                origin: "moz-proxy://127.0.0.1:8888".into(),
-                http_realm: Some("https://www.example.com".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "test".into(),
-            },
+            origin: "moz-proxy://127.0.0.1:8888".into(),
+            http_realm: Some("https://www.example.com".into()),
+            username: "test".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let test_cases = [
@@ -1201,67 +1169,47 @@ mod tests {
 
         // Note that most URL fixups are tested above, but we have one or 2 here.
         let login_with_full_url = LoginEntry {
-            fields: LoginFields {
-                origin: "http://example.com/foo?query=wtf#bar".into(),
-                form_action_origin: Some("http://example.com/foo?query=wtf#bar".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "test".into(),
-            },
+            origin: "http://example.com/foo?query=wtf#bar".into(),
+            form_action_origin: Some("http://example.com/foo?query=wtf#bar".into()),
+            username: "test".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let login_with_host_unicode = LoginEntry {
-            fields: LoginFields {
-                origin: "http://😍.com".into(),
-                form_action_origin: Some("http://😍.com".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "test".into(),
-            },
+            origin: "http://😍.com".into(),
+            form_action_origin: Some("http://😍.com".into()),
+            username: "test".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let login_with_period_fsu = LoginEntry {
-            fields: LoginFields {
-                origin: "https://example.com".into(),
-                form_action_origin: Some(".".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "test".into(),
-            },
+            origin: "https://example.com".into(),
+            form_action_origin: Some(".".into()),
+            username: "test".into(),
+            password: "test".into(),
+            ..Default::default()
         };
         let login_with_empty_fsu = LoginEntry {
-            fields: LoginFields {
-                origin: "https://example.com".into(),
-                form_action_origin: Some("".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "test".into(),
-            },
+            origin: "https://example.com".into(),
+            form_action_origin: Some("".into()),
+            username: "test".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let login_with_form_submit_and_http_realm = LoginEntry {
-            fields: LoginFields {
-                origin: "https://www.example.com".into(),
-                form_action_origin: Some("https://www.example.com".into()),
-                // If both http_realm and form_action_origin are specified, we drop
-                // the former when fixing up. So for this test we must have an
-                // invalid value in http_realm to ensure we don't validate a value
-                // we end up dropping.
-                http_realm: Some("\n".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "".into(),
-                password: "test".into(),
-            },
+            origin: "https://www.example.com".into(),
+            form_action_origin: Some("https://www.example.com".into()),
+            // If both http_realm and form_action_origin are specified, we drop
+            // the former when fixing up. So for this test we must have an
+            // invalid value in http_realm to ensure we don't validate a value
+            // we end up dropping.
+            http_realm: Some("\n".into()),
+            username: "".into(),
+            password: "test".into(),
+            ..Default::default()
         };
 
         let test_cases = [
@@ -1296,14 +1244,10 @@ mod tests {
         for tc in &test_cases {
             let login = tc.login.clone().fixup().expect("should work");
             if let Some(expected) = tc.fixedup_host {
-                assert_eq!(
-                    login.fields.origin, expected,
-                    "origin not fixed in {:#?}",
-                    tc
-                );
+                assert_eq!(login.origin, expected, "origin not fixed in {:#?}", tc);
             }
             assert_eq!(
-                login.fields.form_action_origin, tc.fixedup_form_action_origin,
+                login.form_action_origin, tc.fixedup_form_action_origin,
                 "form_action_origin not fixed in {:#?}",
                 tc,
             );

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -30,42 +30,40 @@ namespace logins {
     EncryptorDecryptor create_managed_encdec(KeyManager key_manager);
 };
 
-/// The fields you can add or update.
-dictionary LoginFields {
+/// A login entry from the user, not linked to any database record.
+/// The add/update APIs input these.
+dictionary LoginEntry {
+    // login fields
     string origin;
     string? http_realm;
     string? form_action_origin;
     string username_field;
     string password_field;
-};
 
-/// Fields which are encrypted at rest.
-dictionary SecureLoginFields {
+    // secure login fields
     string password;
     string username;
 };
 
-/// Fields specific to database records
-dictionary RecordFields {
+/// A login stored in the database
+dictionary Login {
+    // record fields
     string id;
     i64 times_used;
     i64 time_created;
     i64 time_last_used;
     i64 time_password_changed;
-};
 
-/// A login entry from the user, not linked to any database record.
-/// The add/update APIs input these.
-dictionary LoginEntry {
-    LoginFields fields;
-    SecureLoginFields sec_fields;
-};
+    // login fields
+    string origin;
+    string? http_realm;
+    string? form_action_origin;
+    string username_field;
+    string password_field;
 
-/// A login stored in the database
-dictionary Login {
-    RecordFields record;
-    LoginFields fields;
-    SecureLoginFields sec_fields;
+    // secure login fields
+    string password;
+    string username;
 };
 
 /// These are the errors returned by our public API.

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -9,29 +9,25 @@ namespace logins {
     [Throws=LoginsApiError]
     string create_key();
 
-    /// Decrypt an `EncryptedLogin` to a `Login`
-    [Throws=LoginsApiError]
-    Login decrypt_login(EncryptedLogin login, [ByRef]string encryption_key);
-
-    /// Encrypt a `Login` to an `EncryptedLogin`
-    [Throws=LoginsApiError]
-    EncryptedLogin encrypt_login(Login login, [ByRef]string encryption_key);
-
-    /// Decrypt an encrypted `string` to `SecureLoginFields`
-    [Throws=LoginsApiError]
-    SecureLoginFields decrypt_fields(string sec_fields, [ByRef]string encryption_key);
-
-    /// Encrypt `SecureLoginFields` to an encrypted `string`
-    [Throws=LoginsApiError]
-    string encrypt_fields(SecureLoginFields sec_fields, [ByRef]string encryption_key);
-
-    /// Create a "canary" string, which can be used to test if the encryption key is still valid for the logins data
+    /// Create a "canary" string, which can be used to test if the encryption
+    //key is still valid for the logins data
     [Throws=LoginsApiError]
     string create_canary([ByRef]string text, [ByRef]string encryption_key);
 
-    /// Check that key is still valid using the output of `create_canary`.  `text` much match the text you initially passed to `create_canary()`
+    /// Check that key is still valid using the output of `create_canary`.
+    //`text` much match the text you initially passed to `create_canary()`
     [Throws=LoginsApiError]
     boolean check_canary([ByRef]string canary, [ByRef]string text, [ByRef]string encryption_key);
+
+    /// Utility function to create a StaticKeyManager to be used for the time
+    /// being until support lands for [trait implementation of an UniFFI
+    /// interface](https://mozilla.github.io/uniffi-rs/next/proc_macro/index.html#structs-implementing-traits)
+    /// in UniFFI. 
+    KeyManager create_static_key_manager(string key);
+
+    /// Similar to create_static_key_manager above, create a
+    /// ManagedEncryptorDecryptor by passing in a KeyManager
+    EncryptorDecryptor create_managed_encdec(KeyManager key_manager);
 };
 
 /// The fields you can add or update.
@@ -43,7 +39,7 @@ dictionary LoginFields {
     string password_field;
 };
 
-/// Fields available only while the encryption key is known.
+/// Fields which are encrypted at rest.
 dictionary SecureLoginFields {
     string password;
     string username;
@@ -59,7 +55,7 @@ dictionary RecordFields {
 };
 
 /// A login entry from the user, not linked to any database record.
-/// The add/update APIs input these, alongside an encryption key.
+/// The add/update APIs input these.
 dictionary LoginEntry {
     LoginFields fields;
     SecureLoginFields sec_fields;
@@ -72,15 +68,6 @@ dictionary Login {
     SecureLoginFields sec_fields;
 };
 
-/// An encrypted version of [Login].  This is what we return for all the "read"
-/// APIs - we never return the cleartext of encrypted fields.
-dictionary EncryptedLogin {
-    RecordFields record;
-    LoginFields fields;
-    /// ciphertext of a SecureLoginFields
-    string sec_fields;
-};
-
 /// These are the errors returned by our public API.
 [Error]
 interface LoginsApiError {
@@ -90,8 +77,17 @@ interface LoginsApiError {
     /// Asking to do something with a guid which doesn't exist.
     NoSuchRecord(string reason);
 
-    /// The encryption key supplied of the correct format, but not the correct key.
-    IncorrectKey();
+    /// Encryption key is missing.
+    MissingKey();
+
+    /// Encryption key is not valid.
+    InvalidKey();
+
+    /// encryption failed
+    EncryptionFailed(string reason);
+
+    /// decryption failed
+    DecryptionFailed(string reason);
 
     /// An operation was interrupted at the request of the consuming app.
     Interrupted(string reason);
@@ -107,19 +103,41 @@ interface LoginsApiError {
     UnexpectedLoginsApiError(string reason);
 };
 
+[Trait, WithForeign]
+interface EncryptorDecryptor {
+    [Throws=LoginsApiError]
+    bytes encrypt(bytes cleartext);
+
+    [Throws=LoginsApiError]
+    bytes decrypt(bytes ciphertext);
+};
+
+[Trait, WithForeign]
+interface KeyManager {
+    [Throws=LoginsApiError]
+    bytes get_key();
+};
+
+interface StaticKeyManager {
+    constructor(string key);
+};
+
+interface ManagedEncryptorDecryptor {
+    constructor(KeyManager key_manager);
+};
 
 interface LoginStore {
     [Throws=LoginsApiError]
-    constructor(string path);
+    constructor(string path, EncryptorDecryptor encdec);
 
     [Throws=LoginsApiError]
-    EncryptedLogin add(LoginEntry login, [ByRef]string encryption_key);
+    Login add(LoginEntry login);
 
     [Throws=LoginsApiError]
-    EncryptedLogin update([ByRef] string id, LoginEntry login, [ByRef]string encryption_key);
+    Login update([ByRef] string id, LoginEntry login);
 
     [Throws=LoginsApiError]
-    EncryptedLogin add_or_update(LoginEntry login, [ByRef]string encryption_key);
+    Login add_or_update(LoginEntry login);
 
     [Throws=LoginsApiError]
     boolean delete([ByRef] string id);
@@ -134,16 +152,19 @@ interface LoginStore {
     void touch([ByRef] string id);
 
     [Throws=LoginsApiError]
-    sequence<EncryptedLogin> list();
+    sequence<Login> list();
 
     [Throws=LoginsApiError]
-    sequence<EncryptedLogin> get_by_base_domain([ByRef] string base_domain);
+    sequence<Login> get_by_base_domain([ByRef] string base_domain);
 
     [Throws=LoginsApiError]
-    Login? find_login_to_update(LoginEntry look, [ByRef]string encryption_key);
+    boolean has_logins_by_base_domain([ByRef] string base_domain);
 
     [Throws=LoginsApiError]
-    EncryptedLogin? get([ByRef] string id);
+    Login? find_login_to_update(LoginEntry look);
+
+    [Throws=LoginsApiError]
+    Login? get([ByRef] string id);
 
     [Self=ByArc]
     void register_with_sync_manager();

--- a/components/logins/src/store.rs
+++ b/components/logins/src/store.rs
@@ -197,15 +197,18 @@ mod test {
     use super::*;
     use crate::encryption::test_utils::TEST_ENCDEC;
     use crate::util;
-    use crate::{LoginFields, SecureLoginFields};
     use more_asserts::*;
     use std::cmp::Reverse;
     use std::time::SystemTime;
 
     fn assert_logins_equiv(a: &LoginEntry, b: &Login) {
-        assert_eq!(a.fields, b.fields);
-        assert_eq!(b.sec_fields.username, a.sec_fields.username);
-        assert_eq!(b.sec_fields.password, a.sec_fields.password);
+        assert_eq!(a.origin, b.origin);
+        assert_eq!(a.form_action_origin, b.form_action_origin);
+        assert_eq!(a.http_realm, b.http_realm);
+        assert_eq!(a.username_field, b.username_field);
+        assert_eq!(a.password_field, b.password_field);
+        assert_eq!(b.username, a.username);
+        assert_eq!(b.password, a.password);
     }
 
     #[test]
@@ -216,32 +219,24 @@ mod test {
         let start_us = util::system_time_ms_i64(SystemTime::now());
 
         let a = LoginEntry {
-            fields: LoginFields {
                 origin: "https://www.example.com".into(),
                 form_action_origin: Some("https://www.example.com".into()),
                 username_field: "user_input".into(),
                 password_field: "pass_input".into(),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
                 username: "coolperson21".into(),
                 password: "p4ssw0rd".into(),
-            },
+                ..Default::default()
         };
 
         let b = LoginEntry {
-            fields: LoginFields {
                 origin: "https://www.example2.com".into(),
                 http_realm: Some("Some String Here".into()),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
                 username: "asdf".into(),
                 password: "fdsa".into(),
-            },
+                ..Default::default()
         };
-        let a_id = store.add(a.clone()).expect("added a").record.id;
-        let b_id = store.add(b.clone()).expect("added b").record.id;
+        let a_id = store.add(a.clone()).expect("added a").id;
+        let b_id = store.add(b.clone()).expect("added b").id;
 
         let a_from_db = store
             .get(&a_id)
@@ -249,10 +244,10 @@ mod test {
             .expect("a to exist");
 
         assert_logins_equiv(&a, &a_from_db);
-        assert_ge!(a_from_db.record.time_created, start_us);
-        assert_ge!(a_from_db.record.time_password_changed, start_us);
-        assert_ge!(a_from_db.record.time_last_used, start_us);
-        assert_eq!(a_from_db.record.times_used, 1);
+        assert_ge!(a_from_db.time_created, start_us);
+        assert_ge!(a_from_db.time_password_changed, start_us);
+        assert_ge!(a_from_db.time_last_used, start_us);
+        assert_eq!(a_from_db.times_used, 1);
 
         let b_from_db = store
             .get(&b_id)
@@ -260,10 +255,10 @@ mod test {
             .expect("b to exist");
 
         assert_logins_equiv(&LoginEntry { ..b.clone() }, &b_from_db);
-        assert_ge!(b_from_db.record.time_created, start_us);
-        assert_ge!(b_from_db.record.time_password_changed, start_us);
-        assert_ge!(b_from_db.record.time_last_used, start_us);
-        assert_eq!(b_from_db.record.times_used, 1);
+        assert_ge!(b_from_db.time_created, start_us);
+        assert_ge!(b_from_db.time_password_changed, start_us);
+        assert_ge!(b_from_db.time_last_used, start_us);
+        assert_eq!(b_from_db.times_used, 1);
 
         let mut list = store.list().expect("Grabbing list to work");
         assert_eq!(list.len(), 2);
@@ -307,10 +302,8 @@ mod test {
 
         let now_us = util::system_time_ms_i64(SystemTime::now());
         let b2 = LoginEntry {
-            sec_fields: SecureLoginFields {
-                username: b.sec_fields.username.to_owned(),
-                password: "newpass".into(),
-            },
+            username: b.username.to_owned(),
+            password: "newpass".into(),
             ..b
         };
 
@@ -324,12 +317,12 @@ mod test {
             .expect("b to exist");
 
         assert_logins_equiv(&b2, &b_after_update);
-        assert_ge!(b_after_update.record.time_created, start_us);
-        assert_le!(b_after_update.record.time_created, now_us);
-        assert_ge!(b_after_update.record.time_password_changed, now_us);
-        assert_ge!(b_after_update.record.time_last_used, now_us);
+        assert_ge!(b_after_update.time_created, start_us);
+        assert_le!(b_after_update.time_created, now_us);
+        assert_ge!(b_after_update.time_password_changed, now_us);
+        assert_ge!(b_after_update.time_last_used, now_us);
         // Should be two even though we updated twice
-        assert_eq!(b_after_update.record.times_used, 2);
+        assert_eq!(b_after_update.times_used, 2);
     }
 
     #[test]

--- a/components/logins/src/sync/engine.rs
+++ b/components/logins/src/sync/engine.rs
@@ -719,43 +719,31 @@ mod tests {
         let store = LoginStore::new_in_memory(TEST_ENCDEC.clone()).unwrap();
 
         let to_add = LoginEntry {
-            fields: LoginFields {
                 form_action_origin: Some("https://www.example.com".into()),
                 origin: "http://not-relevant-here.com".into(),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
                 username: "test".into(),
                 password: "test".into(),
-            },
+                ..Default::default()
         };
-        let first_id = store.add(to_add).expect("should insert first").record.id;
+        let first_id = store.add(to_add).expect("should insert first").id;
 
         let to_add = LoginEntry {
-            fields: LoginFields {
                 form_action_origin: Some("https://www.example1.com".into()),
                 origin: "http://not-relevant-here.com".into(),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
                 username: "test1".into(),
                 password: "test1".into(),
-            },
+                ..Default::default()
         };
-        let second_id = store.add(to_add).expect("should insert second").record.id;
+        let second_id = store.add(to_add).expect("should insert second").id;
 
         let to_add = LoginEntry {
-            fields: LoginFields {
                 http_realm: Some("http://some-realm.com".into()),
                 origin: "http://not-relevant-here.com".into(),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
                 username: "test1".into(),
                 password: "test1".into(),
-            },
+                ..Default::default()
         };
-        let no_form_origin_id = store.add(to_add).expect("should insert second").record.id;
+        let no_form_origin_id = store.add(to_add).expect("should insert second").id;
 
         let engine = LoginsSyncEngine::new(Arc::new(store)).unwrap();
 
@@ -840,15 +828,11 @@ mod tests {
                 .update(
                     "dummy_000001",
                     LoginEntry {
-                        fields: LoginFields {
                             origin: "https://www.example2.com".into(),
                             http_realm: Some("https://www.example2.com".into()),
-                            ..Default::default()
-                        },
-                        sec_fields: SecureLoginFields {
                             username: "test".into(),
                             password: "test".into(),
-                        },
+                            ..Default::default()
                     },
                 )
                 .unwrap();

--- a/components/logins/src/sync/payload.rs
+++ b/components/logins/src/sync/payload.rs
@@ -11,7 +11,7 @@ use crate::encryption::EncryptorDecryptor;
 use crate::error::*;
 use crate::login::ValidateAndFixup;
 use crate::SecureLoginFields;
-use crate::{EncryptedLogin, LoginFields, RecordFields};
+use crate::{EncryptedLogin, LoginEntry, LoginFields, RecordFields};
 use serde_derive::*;
 use sync15::bso::OutgoingBso;
 use sync_guid::Guid;
@@ -64,17 +64,32 @@ impl IncomingLogin {
         p: LoginPayload,
         encdec: &dyn EncryptorDecryptor,
     ) -> Result<Self> {
-        let fields = LoginFields {
+        let original_fields = LoginFields {
             origin: p.hostname,
             form_action_origin: p.form_submit_url,
             http_realm: p.http_realm,
             username_field: p.username_field,
             password_field: p.password_field,
         };
-        let sec_fields = SecureLoginFields {
+        let original_sec_fields = SecureLoginFields {
             username: p.username,
             password: p.password,
         };
+        // we do a bit of a dance here to maybe_fixup() the fields via LoginEntry
+        let original_login_entry = LoginEntry::new(original_fields, original_sec_fields);
+        let login_entry = original_login_entry.maybe_fixup()?.unwrap_or(original_login_entry);
+        let fields = LoginFields {
+            origin: login_entry.origin,
+            form_action_origin: login_entry.form_action_origin,
+            http_realm: login_entry.http_realm,
+            username_field: login_entry.username_field,
+            password_field: login_entry.password_field,
+        };
+        let sec_fields = SecureLoginFields {
+            username: login_entry.username,
+            password: login_entry.password,
+        };
+
         // We handle NULL in the DB for migrated databases and it's wasteful
         // to encrypt the common case of an empty map, so...
         let unknown = if p.unknown_fields.is_empty() {
@@ -93,11 +108,8 @@ impl IncomingLogin {
                     time_last_used: p.time_last_used,
                     times_used: p.times_used,
                 },
-                fields: fields.maybe_fixup()?.unwrap_or(fields),
-                sec_fields: sec_fields
-                    .maybe_fixup()?
-                    .unwrap_or(sec_fields)
-                    .encrypt(encdec)?,
+                fields,
+                sec_fields: sec_fields.encrypt(encdec)?,
             },
             unknown,
         })

--- a/components/logins/src/sync/update_plan.rs
+++ b/components/logins/src/sync/update_plan.rs
@@ -54,7 +54,7 @@ impl UpdatePlan {
         upstream: IncomingLogin,
         upstream_time: ServerTimestamp,
         server_now: ServerTimestamp,
-        encdec: &EncryptorDecryptor,
+        encdec: &dyn EncryptorDecryptor,
     ) -> Result<()> {
         let local_age = SystemTime::now()
             .duration_since(local.local_modified())
@@ -323,7 +323,7 @@ mod tests {
         get_server_modified, insert_encrypted_login, insert_login,
     };
     use crate::db::LoginDb;
-    use crate::encryption::test_utils::TEST_ENCRYPTOR;
+    use crate::encryption::test_utils::TEST_ENCDEC;
     use crate::login::test_utils::enc_login;
 
     fn inc_login(id: &str, password: &str) -> crate::sync::IncomingLogin {
@@ -470,7 +470,7 @@ mod tests {
                 upstream_login,
                 server_record_timestamp.try_into().unwrap(),
                 server_timestamp.try_into().unwrap(),
-                &TEST_ENCRYPTOR,
+                &*TEST_ENCDEC,
             )
             .unwrap();
         update_plan
@@ -536,7 +536,7 @@ mod tests {
                 upstream_login,
                 server_record_timestamp.try_into().unwrap(),
                 server_timestamp.try_into().unwrap(),
-                &TEST_ENCRYPTOR,
+                &*TEST_ENCDEC,
             )
             .unwrap();
         update_plan
@@ -607,7 +607,7 @@ mod tests {
                 upstream_login,
                 server_record_timestamp.try_into().unwrap(),
                 server_timestamp.try_into().unwrap(),
-                &TEST_ENCRYPTOR,
+                &*TEST_ENCDEC,
             )
             .unwrap();
         update_plan

--- a/examples/sync-pass/src/sync-pass.rs
+++ b/examples/sync-pass/src/sync-pass.rs
@@ -10,13 +10,14 @@ use cli_support::fxa_creds::{
     get_account_and_token, get_cli_fxa, get_default_fxa_config, SYNC_SCOPE,
 };
 use cli_support::prompt::{prompt_char, prompt_string, prompt_usize};
-use logins::encryption::{create_key, EncryptorDecryptor};
+use logins::encryption::{create_key, ManagedEncryptorDecryptor, StaticKeyManager};
 use logins::{
-    EncryptedLogin, LoginEntry, LoginFields, LoginStore, LoginsSyncEngine, SecureLoginFields,
+    Login, LoginEntry, LoginFields, LoginStore, LoginsSyncEngine, SecureLoginFields,
     ValidateAndFixup,
 };
+
 use prettytable::{row, Cell, Row, Table};
-use rusqlite::OptionalExtension;
+use std::fs;
 use std::sync::Arc;
 use sync15::{
     client::{sync_multiple, MemoryCachedState, Sync15StorageClientInit},
@@ -112,9 +113,9 @@ fn string_opt_or<'a>(o: &'a Option<String>, or: &'a str) -> &'a str {
     string_opt(o).unwrap_or(or)
 }
 
-fn update_login(login: EncryptedLogin, encdec: &EncryptorDecryptor) -> LoginEntry {
+fn update_login(login: Login) -> LoginEntry {
     let mut record = LoginEntry {
-        sec_fields: login.decrypt_fields(encdec).unwrap(),
+        sec_fields: login.sec_fields,
         fields: login.fields,
     };
     update_encrypted_fields(&mut record.sec_fields, ", leave blank to keep");
@@ -210,7 +211,7 @@ fn show_sql(conn: &rusqlite::Connection, sql: &str) -> Result<()> {
     Ok(())
 }
 
-fn show_all(store: &LoginStore, encdec: &EncryptorDecryptor) -> Result<Vec<String>> {
+fn show_all(store: &LoginStore) -> Result<Vec<String>> {
     let logins = store.list()?;
 
     let mut table = prettytable::Table::new();
@@ -238,12 +239,11 @@ fn show_all(store: &LoginStore, encdec: &EncryptorDecryptor) -> Result<Vec<Strin
     let mut logins_copy = logins.clone();
     logins_copy.sort_by_key(|a| a.guid());
     for login in logins.iter() {
-        let sec_fields = login.decrypt_fields(encdec).unwrap();
         table.add_row(row![
             r->v.len(),
             Fr->&login.guid(),
-            &sec_fields.username,
-            &sec_fields.password,
+            &login.sec_fields.username,
+            &login.sec_fields.password,
             &login.fields.origin,
 
             string_opt_or(&login.fields.form_action_origin, ""),
@@ -267,12 +267,8 @@ fn show_all(store: &LoginStore, encdec: &EncryptorDecryptor) -> Result<Vec<Strin
     Ok(v)
 }
 
-fn prompt_record_id(
-    s: &LoginStore,
-    encdec: &EncryptorDecryptor,
-    action: &str,
-) -> Result<Option<String>> {
-    let index_to_id = show_all(s, encdec)?;
+fn prompt_record_id(s: &LoginStore, action: &str) -> Result<Option<String>> {
+    let index_to_id = show_all(s)?;
     let input = if let Some(input) = prompt_usize(format!("Enter (idx) of record to {}", action)) {
         input
     } else {
@@ -285,51 +281,32 @@ fn prompt_record_id(
     Ok(Some(index_to_id[input].as_str().into()))
 }
 
-fn open_database(db_path: &str) -> Result<(LoginStore, EncryptorDecryptor, String)> {
-    let store = LoginStore::new(db_path)?;
-    // Get or create an encryption key to use
-    let encryption_key = match get_encryption_key(&store) {
-        Some(s) => s,
-        None => {
-            log::warn!("Creating new encryption key");
+fn open_database(db_path: &str) -> Result<(LoginStore, String)> {
+    let encryption_key = get_or_create_encryption_key()?;
+    let encdec = Arc::new(ManagedEncryptorDecryptor::new(Arc::new(
+        StaticKeyManager::new(encryption_key.clone()),
+    )));
+    let store = LoginStore::new(db_path, encdec)?;
+    Ok((store, encryption_key))
+}
+
+fn get_or_create_encryption_key() -> Result<String> {
+    match get_encryption_key() {
+        Ok(encryption_key) => Ok(encryption_key),
+        Err(_) => {
             let encryption_key = create_key()?;
-            set_encryption_key(&store, &encryption_key)?;
-            encryption_key
+            set_encryption_key(encryption_key.clone())?;
+            Ok(encryption_key)
         }
-    };
-    Ok((
-        store,
-        EncryptorDecryptor::new(&encryption_key)?,
-        encryption_key,
-    ))
+    }
 }
 
-// Use loginsSyncMeta as a quick and dirty solution to store the encryption key
-fn get_encryption_key(store: &LoginStore) -> Option<String> {
-    store
-        .db
-        .lock()
-        .query_row(
-            "SELECT value FROM loginsSyncMeta WHERE key = 'sync-pass-key'",
-            [],
-            |r| r.get(0),
-        )
-        .optional()
-        .unwrap()
+fn get_encryption_key() -> Result<String, std::io::Error> {
+    fs::read_to_string("logins.jwk")
 }
 
-fn set_encryption_key(store: &LoginStore, key: &str) -> rusqlite::Result<()> {
-    store
-        .db
-        .lock()
-        .execute(
-            "
-        INSERT INTO  loginsSyncMeta (key, value)
-        VALUES ('sync-pass-key', ?)
-        ",
-            [&key],
-        )
-        .map(|_| ())
+fn set_encryption_key(encryption_key: String) -> Result<(), std::io::Error> {
+    fs::write("logins.jwk", encryption_key)
 }
 
 fn do_sync(
@@ -411,12 +388,12 @@ fn main() -> Result<()> {
     log::debug!("db: {:?}", db_path);
     // Lets not log the encryption key, it's just not a good habit to be in.
 
-    let (store, encdec, encryption_key) = open_database(db_path)?;
+    let (store, encryption_key) = open_database(db_path)?;
     let store = Arc::new(store);
 
     log::info!("Store has {} passwords", store.list()?.len());
 
-    if let Err(e) = show_all(&store, &encdec) {
+    if let Err(e) = show_all(&store) {
         log::warn!("Failed to show initial login data! {}", e);
     }
 
@@ -425,13 +402,13 @@ fn main() -> Result<()> {
             'A' | 'a' => {
                 log::info!("Adding new record");
                 let record = read_login();
-                if let Err(e) = store.add(record, &encryption_key) {
+                if let Err(e) = store.add(record) {
                     log::warn!("Failed to create record! {}", e);
                 }
             }
             'D' | 'd' => {
                 log::info!("Deleting record");
-                match prompt_record_id(&store, &encdec, "delete") {
+                match prompt_record_id(&store, "delete") {
                     Ok(Some(id)) => {
                         if let Err(e) = store.delete(&id) {
                             log::warn!("Failed to delete record! {}", e);
@@ -445,7 +422,7 @@ fn main() -> Result<()> {
             }
             'U' | 'u' => {
                 log::info!("Updating record fields");
-                match prompt_record_id(&store, &encdec, "update") {
+                match prompt_record_id(&store, "update") {
                     Err(e) => {
                         log::warn!("Failed to get record ID! {}", e);
                     }
@@ -461,7 +438,7 @@ fn main() -> Result<()> {
                                 continue;
                             }
                         };
-                        if let Err(e) = store.update(&id, update_login(login_record.clone(), &encdec), &encryption_key) {
+                        if let Err(e) = store.update(&id, update_login(login_record.clone())) {
                             log::warn!("Failed to update record! {}", e);
                         }
                     }
@@ -501,7 +478,7 @@ fn main() -> Result<()> {
                 }
             }
             'V' | 'v' => {
-                if let Err(e) = show_all(&store, &encdec) {
+                if let Err(e) = show_all(&store) {
                     log::warn!("Failed to dump passwords? This is probably bad! {}", e);
                 }
             }
@@ -520,7 +497,7 @@ fn main() -> Result<()> {
             }
             'T' | 't' => {
                 log::info!("Touching (bumping use count) for a record");
-                match prompt_record_id(&store, &encdec, "update") {
+                match prompt_record_id(&store, "update") {
                     Err(e) => {
                         log::warn!("Failed to get record ID! {}", e);
                     }

--- a/testing/sync-test/src/autofill.rs
+++ b/testing/sync-test/src/autofill.rs
@@ -74,8 +74,7 @@ pub fn add_credit_card(
 }
 
 pub fn scrub_credit_card(s: Arc<AutofillStore>) -> AutofillResult<()> {
-    AutofillStore::scrub_encrypted_data(s)
-        .expect("scrub_encrypted_data() to succeed");
+    AutofillStore::scrub_encrypted_data(s).expect("scrub_encrypted_data() to succeed");
     Ok(())
 }
 
@@ -257,7 +256,7 @@ pub fn get_test_group() -> TestGroup {
             ),
             (
                 "test_autofill_credit_cards_with_scrubbed_cards",
-                test_autofill_credit_cards_with_scrubbed_cards
+                test_autofill_credit_cards_with_scrubbed_cards,
             ),
         ],
     )

--- a/testing/sync-test/src/logins.rs
+++ b/testing/sync-test/src/logins.rs
@@ -4,7 +4,6 @@ http://creativecommons.org/publicdomain/zero/1.0/ */
 use crate::auth::TestClient;
 use crate::testing::TestGroup;
 use anyhow::Result;
-use logins::encryption::{create_key, EncryptorDecryptor};
 use logins::{
     ApiResult as LoginResult, Login, LoginEntry, LoginFields, LoginStore, SecureLoginFields,
 };
@@ -26,23 +25,17 @@ pub fn times_used_for_id(s: &LoginStore, id: &str) -> i64 {
         .times_used
 }
 
-pub fn add_login(s: &LoginStore, l: LoginEntry, key: &str) -> LoginResult<Login> {
-    let encrypted = s.add(l, key)?;
-    let fetched = s
-        .get(&encrypted.guid())?
-        .expect("Login we just added to exist");
-    let encdec = EncryptorDecryptor::new(key).unwrap();
-    Ok(fetched.decrypt(&encdec).unwrap())
+pub fn add_login(s: &LoginStore, l: LoginEntry) -> LoginResult<Login> {
+    let login = s.add(l)?;
+    let fetched = s.get(&login.guid())?.expect("Login we just added to exist");
+    Ok(fetched)
 }
 
-pub fn verify_login(s: &LoginStore, l: &Login, key: &str) {
-    let encdec = EncryptorDecryptor::new(key).unwrap();
+pub fn verify_login(s: &LoginStore, l: &Login) {
     let equivalent = s
         .get(&l.guid())
         .expect("get() to succeed")
-        .expect("Expected login to be present")
-        .decrypt(&encdec)
-        .expect("should decrypt");
+        .expect("Expected login to be present");
 
     assert_logins_equiv(&equivalent, l);
 }
@@ -58,35 +51,27 @@ pub fn verify_missing_login(s: &LoginStore, id: &str) {
 pub fn update_login<F: FnMut(&mut Login)>(
     s: &LoginStore,
     id: &str,
-    key: &str,
     mut callback: F,
 ) -> LoginResult<Login> {
-    let encdec = EncryptorDecryptor::new(key).unwrap();
-    let encrypted = s.get(id)?.expect("No such login!");
-    let mut login = encrypted.decrypt(&encdec).unwrap();
+    let mut login = s.get(id)?.expect("No such login!");
     callback(&mut login);
     let to_update = LoginEntry {
         fields: login.fields,
         sec_fields: login.sec_fields,
     };
-    s.update(id, to_update, key)?;
-    Ok(s.get(id)?
-        .expect("Just updated this")
-        .decrypt(&encdec)
-        .unwrap())
+    s.update(id, to_update)?;
+    Ok(s.get(id)?.expect("Just updated this"))
 }
 
-pub fn touch_login(s: &LoginStore, id: &str, times: usize, key: &str) -> LoginResult<Login> {
+pub fn touch_login(s: &LoginStore, id: &str, times: usize) -> LoginResult<Login> {
     for _ in 0..times {
         s.touch(id)?;
     }
-    let encdec = EncryptorDecryptor::new(key).unwrap();
-    Ok(s.get(id)?.unwrap().decrypt(&encdec).unwrap())
+    Ok(s.get(id)?.unwrap())
 }
 
-pub fn sync_logins(client: &mut TestClient, key: &str) -> Result<()> {
-    let mut local_encryption_keys = HashMap::new();
-    local_encryption_keys.insert("passwords".to_string(), key.to_string());
+pub fn sync_logins(client: &mut TestClient) -> Result<()> {
+    let local_encryption_keys = HashMap::new();
     client.sync(&["passwords".to_string()], local_encryption_keys)
 }
 
@@ -94,8 +79,6 @@ pub fn sync_logins(client: &mut TestClient, key: &str) -> Result<()> {
 
 fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
     log::info!("Add some logins to client0");
-
-    let key = create_key().unwrap();
 
     let l0id = add_login(
         &c0.logins_store,
@@ -112,12 +95,11 @@ fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
                 password: "hunter2".into(),
             },
         },
-        &key,
     )
     .expect("add l0")
     .guid();
 
-    let login0_c0 = touch_login(&c0.logins_store, &l0id, 2, &key).expect("touch0 c0");
+    let login0_c0 = touch_login(&c0.logins_store, &l0id, 2).expect("touch0 c0");
     assert_eq!(login0_c0.record.times_used, 3);
 
     let login1_c0 = add_login(
@@ -133,25 +115,24 @@ fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
                 password: "sekret".into(),
             },
         },
-        &key,
     )
     .expect("add l1");
     let l1id = login1_c0.guid();
 
     log::info!("Syncing client0");
-    sync_logins(c0, &key).expect("c0 sync to work");
+    sync_logins(c0).expect("c0 sync to work");
 
     // Should be the same after syncing.
-    verify_login(&c0.logins_store, &login0_c0, &key);
-    verify_login(&c0.logins_store, &login1_c0, &key);
+    verify_login(&c0.logins_store, &login0_c0);
+    verify_login(&c0.logins_store, &login1_c0);
 
     log::info!("Syncing client1");
-    sync_logins(c1, &key).expect("c1 sync to work");
+    sync_logins(c1).expect("c1 sync to work");
 
     log::info!("Check state");
 
-    verify_login(&c1.logins_store, &login0_c0, &key);
-    verify_login(&c1.logins_store, &login1_c0, &key);
+    verify_login(&c1.logins_store, &login0_c0);
+    verify_login(&c1.logins_store, &login1_c0);
 
     assert_eq!(
         times_used_for_id(&c1.logins_store, &l0id),
@@ -162,31 +143,31 @@ fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
     log::info!("Update logins");
 
     // Change login0 on both
-    update_login(&c1.logins_store, &l0id, &key, |l| {
+    update_login(&c1.logins_store, &l0id, |l| {
         l.sec_fields.password = "testtesttest".into();
     })
     .unwrap();
 
-    let login0_c0 = update_login(&c0.logins_store, &l0id, &key, |l| {
+    let login0_c0 = update_login(&c0.logins_store, &l0id, |l| {
         l.fields.username_field = "users_name".into();
     })
     .unwrap();
 
     // and login1 on remote.
-    let login1_c1 = update_login(&c1.logins_store, &l1id, &key, |l| {
+    let login1_c1 = update_login(&c1.logins_store, &l1id, |l| {
         l.sec_fields.username = "less_cool_username".into();
     })
     .unwrap();
 
     log::info!("Sync again");
 
-    sync_logins(c1, &key).expect("c1 sync 2");
-    sync_logins(c0, &key).expect("c0 sync 2");
+    sync_logins(c1).expect("c1 sync 2");
+    sync_logins(c0).expect("c0 sync 2");
 
     log::info!("Check state again");
 
     // Ensure the remotely changed password change made it through
-    verify_login(&c0.logins_store, &login1_c1, &key);
+    verify_login(&c0.logins_store, &login1_c1);
 
     // And that the conflicting one did too.
     verify_login(
@@ -202,7 +183,6 @@ fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
             },
             record: login0_c0.record,
         },
-        &key,
     );
 
     assert_eq!(
@@ -220,7 +200,6 @@ fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
 
 fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
     log::info!("Add some logins to client0");
-    let key = create_key().unwrap();
 
     let login0 = add_login(
         &c0.logins_store,
@@ -237,7 +216,6 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
                 password: "hunter2".into(),
             },
         },
-        &key,
     )
     .expect("add l0");
     let l0id = login0.guid();
@@ -255,7 +233,6 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
                 password: "sekret".into(),
             },
         },
-        &key,
     )
     .expect("add l1");
     let l1id = login1.guid();
@@ -273,7 +250,6 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
                 password: "123454321".into(),
             },
         },
-        &key,
     )
     .expect("add l2");
     let l2id = login2.guid();
@@ -291,29 +267,28 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
                 password: "aaaaa".into(),
             },
         },
-        &key,
     )
     .expect("add l3");
     let l3id = login3.guid();
 
     log::info!("Syncing client0");
 
-    sync_logins(c0, &key).expect("c0 sync to work");
+    sync_logins(c0).expect("c0 sync to work");
 
     // Should be the same after syncing.
-    verify_login(&c0.logins_store, &login0, &key);
-    verify_login(&c0.logins_store, &login1, &key);
-    verify_login(&c0.logins_store, &login2, &key);
-    verify_login(&c0.logins_store, &login3, &key);
+    verify_login(&c0.logins_store, &login0);
+    verify_login(&c0.logins_store, &login1);
+    verify_login(&c0.logins_store, &login2);
+    verify_login(&c0.logins_store, &login3);
 
     log::info!("Syncing client1");
-    sync_logins(c1, &key).expect("c1 sync to work");
+    sync_logins(c1).expect("c1 sync to work");
 
     log::info!("Check state");
-    verify_login(&c1.logins_store, &login0, &key);
-    verify_login(&c1.logins_store, &login1, &key);
-    verify_login(&c1.logins_store, &login2, &key);
-    verify_login(&c1.logins_store, &login3, &key);
+    verify_login(&c1.logins_store, &login0);
+    verify_login(&c1.logins_store, &login1);
+    verify_login(&c1.logins_store, &login2);
+    verify_login(&c1.logins_store, &login3);
 
     // The 4 logins are for the for possible scenarios. All of them should result in the record
     // being deleted.
@@ -335,7 +310,7 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
 
     // case 3a. c0 modifies record (c1 will delete it after c0 syncs so the timestamps line up)
     log::info!("Updating {} on c0", l2id);
-    let login2_new = update_login(&c0.logins_store, &l2id, &key, |l| {
+    let login2_new = update_login(&c0.logins_store, &l2id, |l| {
         l.sec_fields.username = "foobar".into();
     })
     .unwrap();
@@ -345,30 +320,30 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
 
     // Sync c1
     log::info!("Syncing c1");
-    sync_logins(c1, &key).expect("c1 sync to work");
+    sync_logins(c1).expect("c1 sync to work");
     log::info!("Checking c1 state after sync");
 
     verify_missing_login(&c1.logins_store, &l0id);
     verify_missing_login(&c1.logins_store, &l1id);
-    verify_login(&c1.logins_store, &login2, &key);
+    verify_login(&c1.logins_store, &login2);
     verify_missing_login(&c1.logins_store, &l3id);
 
     log::info!("Update {} on c0", l3id);
     // 4b
-    update_login(&c0.logins_store, &l3id, &key, |l| {
+    update_login(&c0.logins_store, &l3id, |l| {
         l.sec_fields.password = "quux".into();
     })
     .unwrap();
 
     // Sync c0
     log::info!("Syncing c0");
-    sync_logins(c0, &key).expect("c0 sync to work");
+    sync_logins(c0).expect("c0 sync to work");
 
     log::info!("Checking c0 state after sync");
 
     verify_missing_login(&c0.logins_store, &l0id);
     verify_missing_login(&c0.logins_store, &l1id);
-    verify_login(&c0.logins_store, &login2_new, &key);
+    verify_login(&c0.logins_store, &login2_new);
     verify_missing_login(&c0.logins_store, &l3id);
 
     log::info!("Delete {} on c1", l2id);
@@ -376,14 +351,14 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
     assert!(c1.logins_store.delete(&l2id).expect("Delete should work"));
 
     log::info!("Syncing c1");
-    sync_logins(c1, &key).expect("c1 sync to work");
+    sync_logins(c1).expect("c1 sync to work");
 
     log::info!("{} should stay dead", l2id);
     // Ensure we didn't revive it.
     verify_missing_login(&c1.logins_store, &l2id);
 
     log::info!("Syncing c0");
-    sync_logins(c0, &key).expect("c0 sync to work");
+    sync_logins(c0).expect("c0 sync to work");
     log::info!("Should delete {}", l2id);
     verify_missing_login(&c0.logins_store, &l2id);
 }

--- a/testing/sync-test/src/main.rs
+++ b/testing/sync-test/src/main.rs
@@ -5,10 +5,9 @@ http://creativecommons.org/publicdomain/zero/1.0/ */
 #![warn(rust_2018_idioms)]
 
 use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config, SYNC_SCOPE};
-use std::{collections::HashSet, process};
 use std::sync::Arc;
+use std::{collections::HashSet, process};
 use structopt::StructOpt;
-
 
 mod auth;
 mod autofill;
@@ -78,7 +77,8 @@ pub fn run_test_group(opts: &Opts, group: TestGroup) {
     }
 
     let cfg = get_default_fxa_config();
-    let cli_fxa = get_cli_fxa(cfg, &opts.credential_file, &[SYNC_SCOPE]).expect("can't initialize cli");
+    let cli_fxa =
+        get_cli_fxa(cfg, &opts.credential_file, &[SYNC_SCOPE]).expect("can't initialize cli");
     let acct = Arc::new(cli_fxa);
 
     let mut user = TestUser::new(acct, 2).expect("Failed to get test user.");

--- a/testing/sync-test/src/sync15.rs
+++ b/testing/sync-test/src/sync15.rs
@@ -16,9 +16,7 @@ use std::cell::{Cell, RefCell};
 use std::mem;
 use sync15::bso::{IncomingBso, OutgoingBso};
 use sync15::client::{sync_multiple, MemoryCachedState};
-use sync15::engine::{
-    CollectionRequest, EngineSyncAssociation, SyncEngine,
-};
+use sync15::engine::{CollectionRequest, EngineSyncAssociation, SyncEngine};
 use sync15::{telemetry, ServerTimestamp};
 use sync_guid::Guid;
 
@@ -87,10 +85,10 @@ impl SyncEngine for TestEngine {
         // the RefCell.
         let temp: Vec<TestRecord> = mem::take(&mut *self.test_records.borrow_mut());
 
-        Ok(temp.into_iter()
-                .map(OutgoingBso::from_content_with_id)
-                .collect::<Result<_, _>>()?
-        )
+        Ok(temp
+            .into_iter()
+            .map(OutgoingBso::from_content_with_id)
+            .collect::<Result<_, _>>()?)
     }
 
     fn set_uploaded(


### PR DESCRIPTION
This [topic only came up late in the review process](https://github.com/mozilla/application-services/pull/6469#discussion_r1884089244), but it makes perfect sense. Furthermore, it is advisable to combine this change with the other changes, as it makes sense in terms of content and we thus avoid further dependency problems.


The current login structure is nested:

```
Login {
  RecordFields record;
  LoginFields fields;
  SecureLoginFields sec_fields;
}
```

and thus exposes internal data structuring to the consumer. Since we make the encryption transparent for the consumer (Android, iOS, desktop) here, such a separation no longer makes sense here and above can be simplified to

```
Login {
    // record fields
    string id;
    i64 times_used;
    i64 time_created;
    i64 time_last_used;
    i64 time_password_changed;

    // login fields
    string origin;
    string? http_realm;
    string? form_action_origin;
    string username_field;
    string password_field;

    // secure login fields
    string password;
    string username;
}
```


The advantage of eliminating this separation lies, on the one hand, in the simplification of the API and the resulting easier use of the component, and on the other hand, in the easier changeability of the internal data structure. If, for example, we decide later to encrypt additional fields, such a change is possible without having to adapt the consumers.